### PR TITLE
Add support for TOC `header`

### DIFF
--- a/packages/next-docs-ui/src/components/toc.tsx
+++ b/packages/next-docs-ui/src/components/toc.tsx
@@ -5,10 +5,15 @@ import type { TOCItemType } from 'next-docs-zeta/server'
 import * as Primitive from 'next-docs-zeta/toc'
 import { useContext, type ReactNode } from 'react'
 
-export function TOC(props: { items: TOCItemType[]; footer: ReactNode }) {
+export function TOC(props: { items: TOCItemType[]; header: ReactNode, footer: ReactNode }) {
   return (
     <div className="nd-relative nd-w-[250px] max-xl:nd-hidden">
       <div className="nd-sticky nd-flex nd-flex-col nd-top-16 nd-gap-4 nd-py-16 nd-max-h-[calc(100vh-4rem)]">
+        {props.header && (
+          <div className="nd-flex nd-flex-col nd-border-b nd-pb-4 first:nd-border-b-0 first:nd-pb-0">
+            {props.header}
+          </div>
+        )}
         {props.items.length > 0 && <TOCItems items={props.items} />}
         {props.footer && (
           <div className="nd-flex nd-flex-col nd-border-t nd-pt-4 first:nd-border-t-0 first:nd-pt-0">

--- a/packages/next-docs-ui/src/page.tsx
+++ b/packages/next-docs-ui/src/page.tsx
@@ -16,7 +16,11 @@ export type DocsPageProps = {
     enabled: boolean
     component: ReactNode
     /**
-     * Custom content in TOC container
+     * Custom content in TOC container, before the main TOC
+     */
+    header: ReactNode
+    /**
+     * Custom content in TOC container, after the main TOC
      */
     footer: ReactNode
   }>
@@ -52,7 +56,7 @@ export function DocsPage({
       </article>
       {replaceOrDefault(
         tableOfContent,
-        <TOC items={props.toc ?? []} footer={tableOfContent.footer} />
+        <TOC items={props.toc ?? []} header={tableOfContent.header} footer={tableOfContent.footer} />
       )}
     </>
   )


### PR DESCRIPTION
We already got `footer`, so why not `header`.

Context: I'm using this header over at nextjs-faq.com, so...